### PR TITLE
Add ES6 config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,15 @@ Use this config as the base for your `eslintrc` config:
   }
 }
 ```
+
+### ES6
+
+If you would like to use ES6, extend from the `ES6` config:
+
+```
+{
+  "extends: "underdog/es6",
+  "rules": {
+  }
+}
+```

--- a/es6.js
+++ b/es6.js
@@ -1,0 +1,7 @@
+module.exports = {
+  extends: './index.js',
+  parserOptions: {
+    ecmaVersion: 6,
+    sourceType: 'module'
+  }
+};

--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "description": "Base ESLint styles by Underdog.io",
   "main": "index.js",
   "scripts": {
-    "lint": "eslint -c ./index.js ./**/*.js",
+    "lint": "npm run lint-es5 && npm run lint-es6",
+    "lint-es5": "eslint -c ./index.js ./index.js ./test/index.js",
+    "lint-es6": "eslint -c ./es6.js ./**/*.js",
     "test": "npm run lint"
   },
   "repository": {

--- a/test/es6.js
+++ b/test/es6.js
@@ -1,0 +1,3 @@
+import {log} from 'console';
+
+log((cb) => cb(5 + 5));

--- a/test/index.js
+++ b/test/index.js
@@ -1,0 +1,6 @@
+function add5 (value) {
+  var result = value + 5;
+  return result;
+}
+
+add5(10);


### PR DESCRIPTION
Adds a config file with ES6 rules enabled.

To use, extend from `underdog/es6`:

``` json
{
  "extends: "underdog/es6",
  "rules": {
  }
}
```

/cc @underdogio/engineering
