### PR TITLE
Increase max parameters from 3 to 4

### DIFF
--- a/index.js
+++ b/index.js
@@ -77,7 +77,7 @@ module.exports = {
     'max-depth': 2,
     'max-len': 0,
     'max-nested-callbacks': 2,
-    'max-params': 2,
+    'max-params': ['error', 4],
     'max-statements': [
       2,
       20


### PR DESCRIPTION
Increases the allowed amount of parameters from 3 to 4.

The real reason for this PR is that `express` only recognizes error handlers if they have 4 parameters:

``` js
app.use(function (error, req, res, next) {
  // handle teh error
});
```

/cc @underdogio/engineering 
