### PR TITLE
Require parentheses before function parentheses

### DIFF
--- a/index.js
+++ b/index.js
@@ -202,7 +202,7 @@ module.exports = {
     'sort-imports': 2,
     'sort-vars': 2,
     'space-before-blocks': 2,
-    'space-before-function-paren': 0,
+    'space-before-function-paren': 2,
     'space-in-parens': [
       2,
       'never'


### PR DESCRIPTION
Enables a rule for requiring a space before a function declaration's opening parentheses.

``` js
function doAThing () {
  // ok
}

function doAThingWrong() {
  // Not ok
}
```

/cc @underdogio/engineering 
