### PR TITLE
Add rules for React

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,15 @@ If you would like to use ES6, extend from the `ES6` config:
   }
 }
 ```
+
+### React
+
+If you are using React, extend from the `React` config:
+
+```
+{
+  "extends: "underdog/react",
+  "rules": {
+  }
+}
+```

--- a/package.json
+++ b/package.json
@@ -4,9 +4,10 @@
   "description": "Base ESLint styles by Underdog.io",
   "main": "index.js",
   "scripts": {
-    "lint": "npm run lint-es5 && npm run lint-es6",
+    "lint": "npm run lint-es5 && npm run lint-es6 && npm run lint-react",
     "lint-es5": "eslint -c ./index.js ./index.js ./test/index.js",
     "lint-es6": "eslint -c ./es6.js ./**/*.js",
+    "lint-react": "eslint -c ./react.js ./**/*.jsx",
     "test": "npm run lint"
   },
   "repository": {
@@ -34,5 +35,8 @@
   },
   "devDependencies": {
     "eslint": "2.8.0"
+  },
+  "dependencies": {
+    "eslint-plugin-react": "6.2.0"
   }
 }

--- a/react.js
+++ b/react.js
@@ -1,0 +1,11 @@
+module.exports = {
+  extends: ['./es6.js', 'plugin:react/recommended'],
+  plugins: [
+    "react"
+  ],
+  parserOptions: {
+    ecmaFeatures: {
+      jsx: true
+    }
+  }
+};

--- a/test/react.jsx
+++ b/test/react.jsx
@@ -1,0 +1,19 @@
+import React from 'react';
+
+class TestComponent extends React.Component {
+  render () {
+    const {message} = this.props;
+
+    return (
+      <div>
+        {message}
+      </div>
+    );
+  }
+}
+
+TestComponent.propTypes = {
+  message: React.PropTypes.string
+};
+
+export default TestComponent;


### PR DESCRIPTION
Adds some rules for React / JSX. These rules make use of [eslint-plugin-react](https://github.com/yannickcr/eslint-plugin-react), which provides some handy rules for stuff like this:

<img width="740" alt="screen shot 2016-09-09 at 4 07 34 pm" src="https://cloud.githubusercontent.com/assets/6979137/18401293/da2950aa-76a7-11e6-8ad8-d404759a89e3.png">

Right now the rules are set by some defaults that the react plugin provides, but we can come back and tweak them manually if we have to.

/cc @underdogio/engineering  
