### PR TITLE
Test on Node 6.4 and latest stable version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,4 @@
 language: node_js
 node_js:
-  - "4.1"
-  - "4.0"
-  - "0.12"
-  - "0.10"
-  - "iojs"
+  - "6.4"
   - "stable"


### PR DESCRIPTION
Restricts the versions of Node that we are testing with to the version we are using (6.4.x), and the latest stable version.

/cc @underdogio/engineering 
