### PR TITLE
Allow line breaks in arrow functions

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ module.exports = {
     'accessor-pairs': 2,
     'array-bracket-spacing': 2,
     'array-callback-return': 2,
-    'arrow-body-style': 2,
+    'arrow-body-style': 0,
     'arrow-parens': 2,
     'arrow-spacing': 2,
     'block-scoped-var': 2,

--- a/test/es6.js
+++ b/test/es6.js
@@ -1,3 +1,7 @@
 import {log} from 'console';
 
 log((cb) => cb(5 + 5));
+
+[0, 1].map((item) => {
+  return item;
+});


### PR DESCRIPTION
There are some cases where you want a line break in a fat arrow function that begins with a return statement, like if you are writing JSX; a lot of JSX can be hard read if you are forced to write it all in a single line.

/cc @underdogio/engineering 
