### PR TITLE
Remove 'sort-imports' rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -195,7 +195,6 @@ module.exports = {
     'require-yield': 2,
     'semi': 2,
     'semi-spacing': 2,
-    'sort-imports': 2,
     'sort-vars': 2,
     'space-before-blocks': 2,
     'space-before-function-paren': 2,


### PR DESCRIPTION
This rule is forcing us to sort our imports alphabetically, which doesn't really make the most sense IMO. We should instead sort import modules like we do in our non-ES6 projects, with imports from external dependencies coming before local module imports. 